### PR TITLE
Story, or main/home view, is displaying Kid names and their associated story prompts

### DIFF
--- a/bedtime_story_prompter_project/bspapp/models/kid.py
+++ b/bedtime_story_prompter_project/bspapp/models/kid.py
@@ -6,3 +6,6 @@ class Kid(models.Model):
 
     kid_first_name = models.CharField(max_length=50)
     user = models.ForeignKey(User, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return self.kid_first_name

--- a/bedtime_story_prompter_project/bspapp/models/story_prompt.py
+++ b/bedtime_story_prompter_project/bspapp/models/story_prompt.py
@@ -7,3 +7,6 @@ class StoryPrompt(models.Model):
 
     text = models.CharField(max_length=1000)
     kid = models.ForeignKey(Kid, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return self.text

--- a/bedtime_story_prompter_project/bspapp/templates/home.html
+++ b/bedtime_story_prompter_project/bspapp/templates/home.html
@@ -1,1 +1,16 @@
-<h1>Welcome home my child</h1>
+{% load static %}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Story List view</title>
+  </head>
+  <body>
+    {% for kid in kids %}
+        <h1>{{ kid.kid_first_name}}'s story prompts</h1>
+        {% for storyprompt in kid.storyprompt_set.all %}
+             <p>{{storyprompt}}</p>
+        {% endfor %}
+    {% endfor %}
+  </body>
+</html>

--- a/bedtime_story_prompter_project/bspapp/views/home.py
+++ b/bedtime_story_prompter_project/bspapp/views/home.py
@@ -1,8 +1,19 @@
 from django.shortcuts import render
+from django.contrib.auth.decorators import login_required
+from ..models.kid import Kid
 
+@login_required
 def home(request):
     if request.method == 'GET':
+        kids = Kid.objects.all()
+        for kid in kids:
+            for storyprompt in kid.storyprompt_set.all():
+                print(storyprompt) # This prints the story prompts in the terminal.
+            # print("********************", kid.storyprompt_set.all() ) # _set is a Django reserved ORM method to get an array of items with this object's foreign key from another table.
         template = 'home.html'
-        context = {}
+        context = {
+            "kids": kids
+        }
 
         return render(request, template, context)
+


### PR DESCRIPTION
Upon logging in, the home view displays the user's list of kids and, for each kid, their accompanying story prompts. Do the following to test:

1. `git fetch --all`
1. `git checkout rhc_story-main-home-view`
1.  Ensure your server is running
1. In your database, ensure you have at least one user, one kid, and one story prompt associated with that kid
1. In your browser, navigate to `http://127.0.0.1:8000/` to display the home screen (see image below)
___NOTE__: You may need to login_

![image](https://user-images.githubusercontent.com/54753720/77107082-227d6e80-69ee-11ea-8647-51245cba8a7d.png)
6. Ensure the kid and story prompt you entered in the database are displaying