### PR TITLE
Rhc story elements screen

### DIFF
--- a/bedtime_story_prompter_project/bedtime_story_prompter/urls.py
+++ b/bedtime_story_prompter_project/bedtime_story_prompter/urls.py
@@ -24,4 +24,5 @@ urlpatterns = [
     path('register/', register_user, name="register"),
     path('accounts/', include('django.contrib.auth.urls')),
     path('logout/', logout_user, name='logout'),
+    path('storyelements/', story_elements, name='story_elements'),
 ]

--- a/bedtime_story_prompter_project/bspapp/models/challenge.py
+++ b/bedtime_story_prompter_project/bspapp/models/challenge.py
@@ -6,3 +6,6 @@ class Challenge(models.Model):
 
     description = models.CharField(max_length=200)
     user = models.ForeignKey(User, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return self.description

--- a/bedtime_story_prompter_project/bspapp/models/hero.py
+++ b/bedtime_story_prompter_project/bspapp/models/hero.py
@@ -6,3 +6,6 @@ class Hero(models.Model):
 
     name = models.CharField(max_length=100)
     user = models.ForeignKey(User, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return self.name

--- a/bedtime_story_prompter_project/bspapp/models/story_setting.py
+++ b/bedtime_story_prompter_project/bspapp/models/story_setting.py
@@ -6,3 +6,6 @@ class StorySetting(models.Model):
 
     description = models.CharField(max_length=200)
     user = models.ForeignKey(User, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return self.description

--- a/bedtime_story_prompter_project/bspapp/models/story_template.py
+++ b/bedtime_story_prompter_project/bspapp/models/story_template.py
@@ -6,3 +6,6 @@ class StoryTemplate(models.Model):
 
     template = models.CharField(max_length=1000)
     user = models.ForeignKey(User, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return self.template

--- a/bedtime_story_prompter_project/bspapp/models/villain.py
+++ b/bedtime_story_prompter_project/bspapp/models/villain.py
@@ -6,3 +6,6 @@ class Villain(models.Model):
 
     name = models.CharField(max_length=100)
     user = models.ForeignKey(User, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return self.name

--- a/bedtime_story_prompter_project/bspapp/templates/story_elements.html
+++ b/bedtime_story_prompter_project/bspapp/templates/story_elements.html
@@ -1,0 +1,1 @@
+<h1>You did it. You're great. I love you.</h1>

--- a/bedtime_story_prompter_project/bspapp/templates/story_elements.html
+++ b/bedtime_story_prompter_project/bspapp/templates/story_elements.html
@@ -1,1 +1,35 @@
-<h1>You did it. You're great. I love you.</h1>
+{% load static %}
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Story element view</title>
+  </head>
+  <body>
+    {% for user in users %}
+        <h1>Heroes</h1>
+        {% for hero in user.hero_set.all %}
+            <p>{{ hero }}</p>
+        {% endfor %}
+        <h1>Villains</h1>
+        {% for villain in user.villain_set.all %}
+            <p>{{ villain }}</p>
+        {% endfor %}
+        <h1>Settings</h1>
+        {% for setting in user.storysetting_set.all %}
+            <p>{{ setting }}</p>
+        {% endfor %}
+        <h1>Challenges</h1>
+        {% for challenge in user.challenge_set.all %}
+            <p>{{ challenge }}</p>
+        {% endfor %}
+        <h1>Story templates</h1>
+        {% for template in user.storytemplate_set.all %}
+            <p>{{ template }}</p>
+        {% endfor %}
+        {% comment %} {% for storyprompt in kid.storyprompt_set.all %}
+             <p>{{storyprompt}}</p>
+        {% endfor %} {% endcomment %}
+    {% endfor %}
+  </body>
+</html>

--- a/bedtime_story_prompter_project/bspapp/views/__init__.py
+++ b/bedtime_story_prompter_project/bspapp/views/__init__.py
@@ -1,3 +1,4 @@
 from .register import register_user
 from .home import home
 from .auth.logout import logout_user
+from .story_elements import story_elements

--- a/bedtime_story_prompter_project/bspapp/views/story_elements.py
+++ b/bedtime_story_prompter_project/bspapp/views/story_elements.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.models import User
 from ..models.challenge import Challenge
 from ..models.hero import Hero
 from ..models.villain import Villain
@@ -10,11 +11,13 @@ from ..models.story_setting import StorySetting
 @login_required
 def story_elements(request):
      if request.method == 'GET':
-        story_elements = user.objects.all()
+        users = User.objects.all()
+        for user in users:
+            print("**********************", user.hero_set.all())
         template = 'story_elements.html'
-        context = {}
-
-        print(story_elements)
+        context = {
+            "users": users
+        }
 
         return render(request, template, context)
 

--- a/bedtime_story_prompter_project/bspapp/views/story_elements.py
+++ b/bedtime_story_prompter_project/bspapp/views/story_elements.py
@@ -1,0 +1,33 @@
+from django.shortcuts import render
+from django.contrib.auth.decorators import login_required
+from ..models.challenge import Challenge
+from ..models.hero import Hero
+from ..models.villain import Villain
+from ..models.story_template import StoryTemplate
+from ..models.story_setting import StorySetting
+
+
+@login_required
+def story_elements(request):
+     if request.method == 'GET':
+        story_elements = user.objects.all()
+        template = 'story_elements.html'
+        context = {}
+
+        print(story_elements)
+
+        return render(request, template, context)
+
+    # if request.method == 'GET':
+
+    #     for user in kids:
+    #         for storyprompt in kid.storyprompt_set.all():
+    #             print(storyprompt) # This prints the story prompts in the terminal.
+    #         # print("********************", kid.storyprompt_set.all() ) # _set is a Django reserved ORM method to get an array of items with this object's foreign key from another table.
+    #     template = 'home.html'
+    #     context = {
+    #         "kids": kids
+    #     }
+
+    #     return render(request, template, context)
+


### PR DESCRIPTION
Upon logging in and navigating to the story elements screen, users will see a list of story element categories (e.g. hero, villain, and son on) and, under each category, a dynamically-generated list of the items in that category. Do the following to test:

1. `git fetch --all`
1. `git checkout rhc_story-elements-screen`
1.  Ensure your server is running
1. In your database, ensure you have at least one user and at least one item in each of the following database tables:
   1. hero
   1. villain
   1. challenge
   1. storysetting
   1. storytemplate
1. In your browser, navigate to `http://127.0.0.1:8000/storyelements` to display the home screen (see screenshot below)
___NOTE__: You may need to login_
1. Ensure the categories and accompanying items are displaying

![image](https://user-images.githubusercontent.com/54753720/77197114-984b0e00-6ab2-11ea-90bf-817b657188a5.png)

